### PR TITLE
Remove toucstart event listener

### DIFF
--- a/jsl/runtime.js
+++ b/jsl/runtime.js
@@ -1780,7 +1780,7 @@ function start()
      });
 
      //Make tap act as click
-    document.addEventListener('touchstart', function(e) {$(document).click(); }, false);   
+    //document.addEventListener('touchstart', function(e) {$(document).click(); }, false);   
      
      
 	$(document).keydown(function(e) {


### PR DESCRIPTION
On modern browsers this looks like it's not needed anymore, instead it creates a double click (the tap and the click events) making some confirmation screens to disappear.

Fixes #55 

- testes on Morph (Ubuntu Touch broser)
- Android default browser